### PR TITLE
Show sudo prompt text.

### DIFF
--- a/tools/runasroot
+++ b/tools/runasroot
@@ -46,8 +46,9 @@ fi
 
 if which sudo &>/dev/null; then
 	while true; do
-		pw="$(dlg --entry --hide-text --text "Please enter your password:" --image=dialog-password --title "Authorization required")" || exit 254
-		if ! echo "$pw" | sudo -Sk bash -c '[[ $EUID == 0 ]]'; then
+		prompt="$(sudo -Sk true < /dev/null 2>&1)"
+		pw="$(dlg --entry --hide-text --text "$prompt" --image=dialog-password --title "Authorization required")" || exit 254
+		if ! echo "$pw" | sudo -S bash -c '[[ $EUID == 0 ]]'; then
 			dlg_e "The installer could not start. Please verify your password is correct and that you have sudo rights and then try again."
 		else
 			create_tmp_script


### PR DESCRIPTION
This is to fix cases where sudo is configured differently and asks for the root password, rather than the user's password. With this PR, instead of displaying a fixed string "Please enter your password", it'll display whatever the prompt says, e.g. "[sudo] password for {user}".