### PR TITLE
Prevent hangups when the user clicks "Cancel" but no part of the file has been downloaded yet.

### DIFF
--- a/tools/gwget
+++ b/tools/gwget
@@ -6,9 +6,9 @@ if [[ -z "$1" ]] || [[ -z "$2" ]]; then
 fi
 
 if which wget &>/dev/null; then
-	wget "$1" -O "$2" 2>&1 | sed -u 's/^[a-zA-Z\-].*//; s/.* \{1,2\}\([0-9]\{1,3\}\)%.*/\1\n#Downloading... \1%/; s/^20[0-9][0-9].*/#Done./' | yad --window-icon=applications-internet --image=gtk-save --geometry=500 --progress --percentage=0 --title "Downloading Pale Moon..." --text "$(echo "$1" | sed 's/&/&amp\;/g')" --auto-close --auto-kill --button=gtk-cancel
+	( echo "#Connecting..."; wget "$1" -O "$2" 2>&1 ) | sed -u 's/^[a-zA-Z\-].*//; s/.* \{1,2\}\([0-9]\{1,3\}\)%.*/\1\n#Downloading... \1%/; s/^20[0-9][0-9].*/#Done./' | yad --window-icon=applications-internet --image=gtk-save --geometry=500 --progress --percentage=0 --title "Downloading Pale Moon..." --text "$(echo "$1" | sed 's/&/&amp\;/g')" --auto-close --auto-kill --button=gtk-cancel
 elif which curl &>/dev/null; then
-	curl -Lf "$1" -o "$2" 2>&1 | stdbuf -oL tr '\r' '\n' | sed -ur 's/^\s*([0-9]+).*/\1\n#Downloading... \1%/' | yad --window-icon=applications-internet --image=gtk-save --geometry=500 --progress --percentage=0 --title "Downloading Pale Moon..." --text "$(echo "$1" | sed 's/&/&amp\;/g')" --auto-close --no-buttons
+	( echo "#Connecting..."; curl -Lf "$1" -o "$2" 2>&1 ) | stdbuf -oL tr '\r' '\n' | sed -ur 's/^\s*([0-9]+).*/\1\n#Downloading... \1%/' | yad --window-icon=applications-internet --image=gtk-save --geometry=500 --progress --percentage=0 --title "Downloading Pale Moon..." --text "$(echo "$1" | sed 's/&/&amp\;/g')" --auto-close --no-buttons
 else
 	exit 2
 fi


### PR DESCRIPTION
While files are being downloaded using the `gwget` script, but no part of it has been actually retrieved, clicking on the cancel button causes the dialog to close down. However, the script gets stuck at this point.

This PR fixes this issue.