### PR TITLE
Remove version selection, show default prompt, fix formatting+spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ A full list of options can be retrieved by executing `./compile --help`.
 When compiled, the installer generates a shell script with data arranged in the
 following manner:
 
-  +-----------------------------------+
-  | <--minified contents of sfx.sh--> |
-  |-----[xz compressed tar data]------|
-  |bin/                               |
-  |    [...]                          |
-  |tools/                             |
-  |    [...]                          |
-  |files/                             |
-  |    [...]                          |
-  |userdocs/                          |
-  |    [...]                          |
-  +-----------------------------------+
+    +-----------------------------------+
+    | <--minified contents of sfx.sh--> |
+    |-----[xz compressed tar data]------|
+    |bin/                               |
+    |    [...]                          |
+    |tools/                             |
+    |    [...]                          |
+    |files/                             |
+    |    [...]                          |
+    |userdocs/                          |
+    |    [...]                          |
+    +-----------------------------------+
 
 ## Licensing information
 

--- a/installer.sh
+++ b/installer.sh
@@ -254,34 +254,8 @@ pminstall ()
     dlg_e "Another version of Pale Moon is already installed. Please remove the installed version and try again."
     return
   fi
-  while true; do
-    pm_ver="$(dlg_q "Press OK to download and install the latest version of Pale Moon." --entry --entry-text "Latest version" --button=gtk-ok:0 --button=gtk-cancel:1 --button="Archived versions...":2)"
-    errorlevel=$?
-    case $errorlevel in
-    0)
-      case "$pm_ver" in
-      Latest*)
-        pm_ver="$(get_latest_version)"
 
-        if ! is_version_valid "$pm_ver"; then
-          dlg_e "The latest version number could not be retrieved. Please check your network connection and try again."
-        else
-          break
-        fi
-        ;;
-      *)
-        dlg_e "Only the latest version can be installed with this script."
-        ;;
-      esac
-    ;;
-    1)
-      return
-      ;;   
-    2)
-      xdg-open https://www.palemoon.org/archived.shtml
-      ;;
-    esac
-  done
+  pm_ver="$(get_latest_version)"
 
   if archive_download "$pm_ver"; then
     pminstall_main >& 1 | stdoutparser | dlg_pw "Installing Pale Moon..." applications-system

--- a/tools/runasroot
+++ b/tools/runasroot
@@ -16,14 +16,14 @@ dlg_e ()
 # Extract the contents of a variable *safely*.
 # Usage: var_extract [extraction_mode] [variable_name]
 # where [extraction_mode] is one of:
-# no_check_existance: Create "export variable_name=[...]" statement.
-# check_existance: Create above with '[[ -z $variable_name ]] &&' prepended.
+# no_check_existence: Create "export variable_name=[...]" statement.
+# check_existence: Create above with '[[ -z $variable_name ]] &&' prepended.
 var_extract () {
   case "$1" in
-  no_check_existance)
+  no_check_existence)
     declare -x | grep -E "^declare -x $2=" | sed -r 's/^declare -x/export/'
     ;;
-  check_existance)
+  check_existence)
     declare -x | grep -E "^declare -x $2=" | sed -r 's/^declare -x/\[\[ -z $'"$2"' ]] \&\& export/'
     ;;
   esac
@@ -34,12 +34,12 @@ create_tmp_script ()
 {
   tmp_script=$(mktemp /tmp/runasroot.XXXXXXXXX)
   echo '#!/bin/bash' > $tmp_script
-  var_extract no_check_existance DISPLAY >> $tmp_script
-  var_extract check_existance XAUTHORITY >> $tmp_script
-  var_extract no_check_existance http_proxy >> $tmp_script
-  var_extract no_check_existance https_proxy >> $tmp_script
-  var_extract no_check_existance ftp_proxy >> $tmp_script
-  var_extract no_check_existance no_proxy >> $tmp_script
+  var_extract no_check_existence DISPLAY >> $tmp_script
+  var_extract check_existence XAUTHORITY >> $tmp_script
+  var_extract no_check_existence http_proxy >> $tmp_script
+  var_extract no_check_existence https_proxy >> $tmp_script
+  var_extract no_check_existence ftp_proxy >> $tmp_script
+  var_extract no_check_existence no_proxy >> $tmp_script
   echo 'exec "$@"' >> $tmp_script
   chmod +x $tmp_script
 }

--- a/tools/runasroot
+++ b/tools/runasroot
@@ -66,6 +66,9 @@ fi
 if which sudo &>/dev/null; then
   while true; do
     prompt="$(sudo -Sk true < /dev/null 2>&1)"
+    if [[ -z $prompt ]]; then
+      prompt="Enter your password:"
+    fi
     pw="$(dlg --entry --hide-text --text "$prompt" --image=dialog-password --title "Authorization required")" || exit 254
     if ! echo "$pw" | sudo -S bash -c '[[ $EUID == 0 ]]'; then
       dlg_e "The installer could not start. Please verify your password is correct and that you have sudo rights and then try again."


### PR DESCRIPTION
This PR fixes a few "bugs" and some other nits that I found:

* Removes the version selection dialog as per #25 
* Shows a default prompt in the runasroot tool if a default is not available on the system.
* Fixes formatting in README.md and a few spelling nits in the runasroot tool.